### PR TITLE
Add docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Monk ID Ruby
 [![Gem Version](https://badge.fury.io/rb/monk-id.png)](http://badge.fury.io/rb/monk-id)
 [![Build Status](https://travis-ci.org/MonkDev/monk-id-ruby.svg?branch=dev)](https://travis-ci.org/MonkDev/monk-id-ruby)
 [![Code Climate](https://codeclimate.com/github/MonkDev/monk-id-ruby.png)](https://codeclimate.com/github/MonkDev/monk-id-ruby)
+[![Inline docs](http://inch-pages.github.io/github/MonkDev/monk-id-ruby.png)](http://inch-pages.github.io/github/MonkDev/monk-id-ruby)
 [![Coverage Status](https://img.shields.io/coveralls/MonkDev/monk-id-ruby.svg)](https://coveralls.io/r/MonkDev/monk-id-ruby?branch=dev)
 [![Dependency Status](https://gemnasium.com/MonkDev/monk-id-ruby.svg)](https://gemnasium.com/MonkDev/monk-id-ruby)
 


### PR DESCRIPTION
I just added the badge you requested to your README: ![Inline docs](http://inch-pages.github.io/github/MonkDev/monk-id-ruby.png)

Your status page for this project is http://inch-pages.github.io/github/MonkDev/monk-id-ruby

Thanks for giving this a shot!
